### PR TITLE
Fix compilation of status module on BSD

### DIFF
--- a/modules/status/sound_bsd.go
+++ b/modules/status/sound_bsd.go
@@ -53,7 +53,7 @@ func (b *sound) setup() error {
 
 func (b *sound) setValue(vol int) {
 	volStr := strconv.Itoa(vol)
-	level := vol + ":" + vol
+	level := volStr + ":" + volStr
 	cmd := exec.Command("mixer", "vol", level)
 	if err := cmd.Run(); err != nil {
 		fyne.LogError("Failed to set volume", err)


### PR DESCRIPTION
Looks like a bug crept in during the optimization in the last commit. This commit fixes the compilation error.
It's my fault, but to be fair, this would never have happened if GitHub Actions supported FreeBSD.

Related to #212 