### PR TITLE
Use the correct byte function instead of string convertion

### DIFF
--- a/modules/status/sound_bsd.go
+++ b/modules/status/sound_bsd.go
@@ -3,9 +3,9 @@
 package status
 
 import (
+	"bytes"
 	"os/exec"
 	"strconv"
-	"strings"
 
 	"fyne.io/fyne/v2"
 
@@ -32,7 +32,7 @@ func (b *sound) muted() bool {
 func (b *sound) value() (int, error) {
 	cmd := exec.Command("mixer", "-s", "vol")
 	out, err := cmd.Output()
-	colonPos := strings.Index(string(out), ":")
+	colonPos := bytes.IndexByte(out, ':')
 	if err != nil || colonPos <= 0 {
 		return 0, err
 	}


### PR DESCRIPTION
Just a small change to use the correct bytes function instead of converting to a string.