### PR TITLE
Move the search button to the first app icon

### DIFF
--- a/internal/ui/bar.go
+++ b/internal/ui/bar.go
@@ -177,7 +177,7 @@ func (b *bar) updateTaskbar() {
 }
 
 func (b *bar) updateIconOrder() {
-	var index = -1
+	var index = 0
 	for i, obj := range b.children {
 		if _, ok := obj.(*canvas.Rectangle); ok {
 			index = i
@@ -185,8 +185,8 @@ func (b *bar) updateIconOrder() {
 		}
 	}
 	var taskbarIcons []*barIcon
-	if index != -1 {
-		taskbarIcons = b.icons[index:]
+	if index != 0 {
+		taskbarIcons = b.icons[index-1:]
 	}
 
 	b.icons = nil
@@ -236,6 +236,9 @@ func (b *bar) winIcon(win *appWindow) fyne.Resource {
 }
 
 func (b *bar) appendLauncherIcons() {
+	search := newBarIcon(theme.SearchIcon(), nil, nil)
+	search.onTapped = ShowAppLauncher
+	b.append(search)
 	for _, name := range b.desk.Settings().LauncherIcons() {
 		app := b.desk.IconProvider().FindAppFromName(name)
 		if app == nil {

--- a/internal/ui/bar_test.go
+++ b/internal/ui/bar_test.go
@@ -107,13 +107,14 @@ func TestIconsAndIconThemeChange(t *testing.T) {
 	testBar.updateIcons()
 
 	assert.Equal(t, "Maximize", testBar.desk.Settings().IconTheme())
-	assert.Equal(t, wmTheme.MaximizeIcon, testBar.children[0].(*barIcon).resource)
+	assert.Equal(t, theme.SearchIcon(), testBar.children[0].(*barIcon).resource)
+	assert.Equal(t, wmTheme.MaximizeIcon, testBar.children[1].(*barIcon).resource)
 
 	testBar.desk.Settings().(*wmTest.Settings).SetIconTheme("TestIconTheme")
 	testBar.updateIcons()
 
 	assert.Equal(t, "TestIconTheme", testBar.desk.Settings().IconTheme())
-	assert.Equal(t, wmTheme.IconifyIcon, testBar.children[0].(*barIcon).resource)
+	assert.Equal(t, wmTheme.IconifyIcon, testBar.children[1].(*barIcon).resource)
 }
 
 func TestIconOrderChange(t *testing.T) {
@@ -123,15 +124,16 @@ func TestIconOrderChange(t *testing.T) {
 
 	testBar.desk.Settings().(*wmTest.Settings).SetLauncherIcons([]string{"App1", "App2", "App3"})
 	testBar.updateIconOrder()
-	assert.Equal(t, "App1", testBar.children[0].(*barIcon).appData.Name())
-	assert.Equal(t, "App2", testBar.children[1].(*barIcon).appData.Name())
-	assert.Equal(t, "App3", testBar.children[2].(*barIcon).appData.Name())
+	assert.Equal(t, theme.SearchIcon(), testBar.children[0].(*barIcon).resource)
+	assert.Equal(t, "App1", testBar.children[1].(*barIcon).appData.Name())
+	assert.Equal(t, "App2", testBar.children[2].(*barIcon).appData.Name())
+	assert.Equal(t, "App3", testBar.children[3].(*barIcon).appData.Name())
 
 	testBar.desk.Settings().(*wmTest.Settings).SetLauncherIcons([]string{"App3", "App1", "App2"})
 	testBar.updateIconOrder()
-	assert.Equal(t, "App3", testBar.children[0].(*barIcon).appData.Name())
-	assert.Equal(t, "App1", testBar.children[1].(*barIcon).appData.Name())
-	assert.Equal(t, "App2", testBar.children[2].(*barIcon).appData.Name())
+	assert.Equal(t, "App3", testBar.children[1].(*barIcon).appData.Name())
+	assert.Equal(t, "App1", testBar.children[2].(*barIcon).appData.Name())
+	assert.Equal(t, "App2", testBar.children[3].(*barIcon).appData.Name())
 }
 
 func TestIconSizeChange(t *testing.T) {
@@ -210,7 +212,7 @@ func TestIconTaskbarDisabled(t *testing.T) {
 	testBar.updateIconOrder()
 
 	separatorTest := false
-	if len(testBar.icons) == len(testBar.children)-1 {
+	if len(testBar.icons) == len(testBar.children)-2 {
 		separatorTest = true
 	}
 	assert.Equal(t, true, separatorTest)

--- a/internal/ui/widgetpanel.go
+++ b/internal/ui/widgetpanel.go
@@ -43,11 +43,9 @@ func (w *widgetRenderer) Refresh() {
 
 	w.panel.account.SetText(w.panel.accountLabel())
 	if w.panel.desk.Settings().NarrowWidgetPanel() {
-		w.panel.search.Hide()
 		w.panel.clocks.Objects[0].Hide()
 		w.panel.clocks.Objects[1].Show()
 	} else {
-		w.panel.search.Show()
 		w.panel.clocks.Objects[0].Show()
 		w.panel.clocks.Objects[1].Hide()
 	}
@@ -69,7 +67,7 @@ type widgetPanel struct {
 	desk            fynedesk.Desktop
 	about, settings fyne.Window
 
-	account, search *widget.Button
+	account         *widget.Button
 	clock, vClock   *canvas.Text
 	date            *widget.Label
 	rotated         *canvas.Image
@@ -168,8 +166,6 @@ func (w *widgetPanel) CreateRenderer() fyne.WidgetRenderer {
 	} else {
 		w.clocks.Objects[1].Hide()
 	}
-	w.search = widget.NewButtonWithIcon("", theme.SearchIcon(), ShowAppLauncher)
-	bottom := container.NewBorder(nil, nil, w.search, nil, w.account)
 
 	bg := canvas.NewRectangle(wmtheme.WidgetPanelBackground())
 	objects := []fyne.CanvasObject{
@@ -180,7 +176,7 @@ func (w *widgetPanel) CreateRenderer() fyne.WidgetRenderer {
 		w.notifications}
 
 	w.modules = container.NewVBox()
-	objects = append(objects, layout.NewSpacer(), w.modules, bottom)
+	objects = append(objects, layout.NewSpacer(), w.modules, w.account)
 	w.loadModules(w.desk.Modules())
 
 	return &widgetRenderer{


### PR DESCRIPTION
As suggested we can remove the icon from the menu and put it with apps where it belongs

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [x] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
