### PR TITLE
Fix Xephyr support in multi-monitor GNOME setups.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ uninstall:
 	-rm $(DESTDIR)$(PREFIX)/share/xsessions/fynedesk.desktop
 
 embed:
-	DISPLAY=:0 Xephyr :1 -screen 1280x720 &
-	DISPLAY=:1 go run ./cmd/fynedesk
+	Xephyr :5 -screen 1280x720 &
+	DISPLAY=:5 go run ./cmd/fynedesk


### PR DESCRIPTION
### Description:
Using a multi-monitor setup of GNOME [1]; The Xephyr embedded Fynedesk session (called by `make embed`) reliably crashes the host window-manager. GNOME recovers from this -- Xephyr launches and connects to Fynedesk, but this results in Fyne defined elements like the 'search box', 'application menu', and any resulting apps to be launched on the host and not in said embedded session.

This PR makes two edits to the 'embed' section of the Makefile; Namely, by dropping the first explicit deceleration of the DISPLAY variable. This should be set by one's host anyways & hard-coding it seems to cause problems at least in this given usecase.  And the second edit, is switching the given display server port to a less often used value; It was suggested we use :2 or :5. Ultimately, :5 was chosen because it seems less likely to conflict with anything.

This is officially "works for me territory" & certainly I don't know the edges of Xephyr or Xorg specific tech in-general. So if there's anything that looks fishy (<_<) about this, let me know!

_Fixes #NA
Discussed On Discord._

### Checklist: NA?
- [ ] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

---
[1] Tested In GNOME 43.2, on Debian 12 Bookworm (Currently 'Testing').