### PR TITLE
Add pinned windows which stick to the position when moving desktops

### DIFF
--- a/internal/ui/desk.go
+++ b/internal/ui/desk.go
@@ -68,8 +68,7 @@ func (l *desktop) SetDesktop(id int) {
 
 	fyne.NewAnimation(canvas.DurationStandard, func(f float32) {
 		for i, item := range l.wm.Windows() {
-			// TODO move this to floating once we support them
-			if item.Properties().SkipTaskbar() {
+			if item.Pinned() {
 				continue
 			}
 

--- a/internal/x11/win/client.go
+++ b/internal/x11/win/client.go
@@ -26,6 +26,7 @@ type client struct {
 	full      bool
 	iconic    bool
 	maximized bool
+	pinned    bool
 	props     *clientProperties
 
 	restoreX, restoreY          int16
@@ -128,6 +129,10 @@ func (c *client) SetDesktop(id int) {
 	d := fynedesk.Instance()
 	diff := id - c.desk
 	c.desk = id
+
+	if c.pinned {
+		return
+	}
 
 	_, height := d.RootSizePixels()
 	offPix := float32(diff * -int(height))
@@ -312,6 +317,16 @@ func (c *client) Parent() fynedesk.Window {
 	return nil
 }
 
+func (c *client) Pin() {
+	c.pinned = true
+	d := fynedesk.Instance()
+	c.SetDesktop(d.Desktop())
+}
+
+func (c *client) Pinned() bool {
+	return c.pinned
+}
+
 func (c *client) Position() fyne.Position {
 	screen := fynedesk.Instance().Screens().ScreenForWindow(c)
 
@@ -407,6 +422,15 @@ func (c *client) Uniconify() {
 
 func (c *client) Unmaximize() {
 	c.maximizeMessage(x11.WindowStateActionRemove)
+}
+
+func (c *client) Unpin() {
+	c.pinned = false
+	d := fynedesk.Instance()
+	id := d.Desktop()
+	c.desk = id
+
+	c.SetDesktop(id)
 }
 
 func (c *client) fullscreenMessage(action x11.WindowStateAction) {

--- a/modules/desktops/pager.go
+++ b/modules/desktops/pager.go
@@ -91,8 +91,13 @@ func (p *pager) refreshFrom(oldID int) {
 			continue
 		}
 
-		yPad := theme.Padding() * float32(win.Desktop()-oldID)
+		deskID := win.Desktop()
+		yPad := theme.Padding() * float32(deskID-oldID)
 		screen := fynedesk.Instance().Screens().ScreenForWindow(win)
+		if win.Pinned() {
+			yPad = theme.Padding() * float32(desk.Desktop()-oldID)
+			yPad -= float32(oldID-desk.Desktop()) * pivot.Size().Height
+		}
 
 		var obj fyne.CanvasObject
 		obj = canvas.NewRectangle(theme.DisabledColor())

--- a/modules/quaketerm/term.go
+++ b/modules/quaketerm/term.go
@@ -139,6 +139,7 @@ func (t *term) toggle() {
 	if !t.shown {
 		t.win = t.getHandle()
 
+		t.win.Pin()
 		t.show()
 	} else {
 		t.hide()

--- a/test/window.go
+++ b/test/window.go
@@ -12,7 +12,7 @@ import (
 type Window struct {
 	props dummyProperties
 
-	iconic, focused, fullscreen, maximized, raised bool
+	iconic, focused, fullscreen, maximized, raised, pinned bool
 
 	parent        fynedesk.Window
 	x, y, desk    int
@@ -87,6 +87,16 @@ func (w *Window) Move(_ fyne.Position) {}
 // Parent returns a window that this should be positioned within, if set.
 func (w *Window) Parent() fynedesk.Window {
 	return w.parent
+}
+
+// Pin requests that the window be visible on all desktops
+func (w *Window) Pin() {
+	w.pinned = true
+}
+
+// Pinned returns true if the window should be visible on all desktops
+func (w *Window) Pinned() bool {
+	return w.pinned
 }
 
 // Position returns 0, 0 for test windows
@@ -164,4 +174,10 @@ func (w *Window) Uniconify() {
 // Unmaximize removes the maximized state of this window
 func (w *Window) Unmaximize() {
 	w.maximized = false
+}
+
+// Unpin resets the state of being visible on all windows.
+// The window will return to being visible on its specified desktop.
+func (w *Window) Unpin() {
+	w.pinned = false
 }

--- a/window.go
+++ b/window.go
@@ -36,6 +36,9 @@ type Window interface {
 
 	Desktop() int
 	SetDesktop(int)
+	Pin()
+	Pinned() bool
+	Unpin()
 }
 
 // WindowProperties encapsulates the metadata that a window can provide.


### PR DESCRIPTION
Looking for a little feedback on naming and/or menu for this feature.
Adds "All desktops" to the "move to desktop" menu...

Does it "fit" for X11 and Wayland?

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [x] Lint and formatter run with no errors.
- [x] Tests all pass.
