### PR TITLE
Simplify ifconfig call and move regex logic to Go

### DIFF
--- a/modules/status/network.go
+++ b/modules/status/network.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 
@@ -81,12 +82,14 @@ func (n *network) isEthernetConnected() (bool, error) {
 			return false, nil
 		}
 	} else {
-		out, err := exec.Command("bash", []string{"-c", "ifconfig | pcregrep -M -o '^[^\\t:]+:([^\\n]|\\n\\t)*status: active'"}...).Output()
+		out, err := exec.Command("ifconfig").Output()
 		if err != nil {
 			log.Println("Error running ifconfig tool", err)
 			return false, err
 		}
-		if !strings.Contains(string(out), "broadcast") {
+		re := regexp.MustCompile(`^[^\t:]+:([^\n]|\n\t)*status: active`)
+		m := re.FindSubmatch(out)
+		if len(m) < 2 || !strings.Contains(string(m[1]), "broadcast") {
 			return false, nil
 		}
 	}

--- a/modules/status/network.go
+++ b/modules/status/network.go
@@ -87,10 +87,22 @@ func (n *network) isEthernetConnected() (bool, error) {
 			log.Println("Error running ifconfig tool", err)
 			return false, err
 		}
-		re := regexp.MustCompile(`^[^\t:]+:([^\n]|\n\t)*status: active`)
+		re, err := regexp.Compile(`^[^\t:]+:([^\n]|\n\t)*status: active`)
+		if err != nil {
+			log.Println("Error compiling regular expression", err)
+			return false, err
+		}
 		m := re.FindSubmatch(out)
-		if len(m) < 2 || !strings.Contains(string(m[1]), "broadcast") {
+		if len(m) < 1 {
 			return false, nil
+		}
+		// IPv4
+		if strings.Contains(string(m[0]), "broadcast") {
+			return true, nil
+		}
+		// IPv6, non-link-local only
+		if found, _ := regexp.MatchString(`\s+inet6\s+[[:xdigit:]:]+\s+prefixlen\s+`, m[0]); found {
+			return true, nil
 		}
 	}
 	return true, nil


### PR DESCRIPTION
<!-- If this is your first pull request for Fyne please read the contributor docs at:
https://github.com/fyne-io/fyne/wiki/Contributing.
Be sure that your work is based off `develop` branch. --> 

### Description:

This should make network detection more reliable by reducing dependencies that aren't available everywhere out of the box (bash, pcregrep). And it adds support for IPv6.

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests included.
- [X] Lint and formatter run with no errors.
- [ ] Tests all pass.

#### Where applicable:
<!-- Please delete these if not required for this PR -->

- [ ] Any breaking changes have a deprecation path or have been discussed.
